### PR TITLE
fix watcher example to work with RPi 4

### DIFF
--- a/example/watcher/watcher.go
+++ b/example/watcher/watcher.go
@@ -22,7 +22,6 @@ func main() {
 
 	offset := rpi.J8p7
 	l, err := c.RequestLine(offset,
-		gpiod.WithPullUp,
 		gpiod.WithBothEdges(func(evt gpiod.LineEvent) {
 			t := time.Now()
 			edge := "rising"

--- a/example/watcher/watcher.go
+++ b/example/watcher/watcher.go
@@ -37,7 +37,7 @@ func main() {
 		}))
 	if err != nil {
 		if err.Error() == "invalid argument" {
-			fmt.Println("An error occured, make sure your kernel version is >= 5.5")
+			fmt.Println("An error occurred, make sure your kernel version is >= 5.5")
 		}
 		panic(err)
 	}

--- a/example/watcher/watcher.go
+++ b/example/watcher/watcher.go
@@ -22,6 +22,7 @@ func main() {
 
 	offset := rpi.J8p7
 	l, err := c.RequestLine(offset,
+		gpiod.WithPullUp,
 		gpiod.WithBothEdges(func(evt gpiod.LineEvent) {
 			t := time.Now()
 			edge := "rising"
@@ -35,6 +36,9 @@ func main() {
 				evt.Timestamp)
 		}))
 	if err != nil {
+		if err.Error() == "invalid argument" {
+			fmt.Println("An error occured, make sure your kernel version is >= 5.5")
+		}
 		panic(err)
 	}
 	defer l.Close()


### PR DESCRIPTION
The original code doesn't work for me on RPi 4. I get:
```
panic: invalid argument

goroutine 1 [running]:
main.main()
        /opt/gpiod/example/watcher/watcher.go:39 +0x24c
exit status 2
```
This change should fix the issue but I am not sure if it is OK for other devices.