### PR TITLE
Chips, and their underlaying fd's, should be closed in FindLine

### DIFF
--- a/gpiocdev.go
+++ b/gpiocdev.go
@@ -1191,6 +1191,8 @@ func FindLine(name string) (chip string, offset int, err error) {
 		if err != nil {
 			continue
 		}
+		defer c.Close()
+
 		offset, err = c.FindLine(name)
 		if err == nil {
 			return


### PR DESCRIPTION
Hi

In FindLine, I would imagine chips and underlying file descriptors should be closed for us not to leak file descriptors  

Best